### PR TITLE
Switch to internal singleton logger.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@ History
 
 ## Current
 
+* Switch to internal Winston logger. ([@didebeach][])
+  Fixes [#3](https://github.com/FormidableLabs/express-winston-middleware/issues/3).
 * Explicitly delete the request logger.
 
 ## 0.0.4
@@ -25,3 +27,4 @@ History
 * Initial release.
 
 [@ryan-roemer]: https://github.com/ryan-roemer
+[@didebeach]: https://github.com/didebeach

--- a/examples/server.js
+++ b/examples/server.js
@@ -14,9 +14,17 @@ var express = require("express"),
     ]
   };
 
+// Uncaught exception handler.
+process.on("uncaughtException", winMid.uncaught(logOpts, {
+  extra: "uncaught"
+}));
+
 // Middleware automatically adds request logging at finish of request.
 app.use(winMid.request(logOpts, {
   type: "per-request-log"
+}));
+app.use(winMid.error(logOpts, {
+  type: "error-log"
 }));
 
 // In addition to the automatic request logging, can **manually** log within
@@ -26,6 +34,12 @@ app.get("/custom-logging", function (req, res) {
     extra: "metadata"
   });
   res.send("Custom message logged...");
+});
+app.get("/error", function (req, res, next) {
+  next(new Error("Error!"));
+});
+app.get("/uncaught", function () {
+  throw new Error("Uncaught exception!");
 });
 
 // Configure static server.

--- a/index.html
+++ b/index.html
@@ -165,6 +165,12 @@ Released under the <a href="./LICENSE.txt">MIT</a> License.</p>
 
         </div>
         <div id="history"><h1 id="history">History</h1>
+<h2 id="current">Current</h2>
+<ul>
+<li>Switch to internal Winston logger. (<a href="https://github.com/didebeach">@didebeach</a>)
+Fixes <a href="https://github.com/FormidableLabs/express-winston-middleware/issues/3">#3</a>.</li>
+<li>Explicitly delete the request logger.</li>
+</ul>
 <h2 id="0-0-4">0.0.4</h2>
 <ul>
 <li>Add client IP request metadata (with logic to get past LB).</li>

--- a/package.json
+++ b/package.json
@@ -10,20 +10,20 @@
     "winston": "*"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-cli": "~0.1.9",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt": "~0.4.1",
-    "grunt-contrib-jade": "~0.8.0",
-    "dox": "~0.4.4",
-    "marked": "~0.2.10",
-    "winston": "~0.7.2",
-    "chai": "~1.8.1",
-    "mocha": "~1.15.1",
-    "grunt-mocha-test": "~0.8.1",
-    "sinon": "~1.7.3",
-    "sinon-chai": "~2.4.0",
-    "express": "~3.4.7"
+    "chai": "^1.8.1",
+    "dox": "^0.4.4",
+    "express": "^3.4.7",
+    "grunt": "^0.4.1",
+    "grunt-cli": "^0.1.9",
+    "grunt-contrib-jade": "^0.8.0",
+    "grunt-contrib-jshint": "^0.7.0",
+    "grunt-contrib-watch": "^0.5.3",
+    "grunt-mocha-test": "^0.8.1",
+    "marked": "^0.2.10",
+    "mocha": "^1.15.1",
+    "sinon": "^1.7.3",
+    "sinon-chai": "^2.4.0",
+    "winston": "^0.9.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/grunt check"


### PR DESCRIPTION
Fixes #3 

* Add `singleton` param to reuse internal Winston logger.
* Switch `error` and `request` middleware to use internal singleton.
* Add more routes for example app.


Watching repeated refreshes with current `master`:

```
$ git checkout master
$ node examples/server.js | grep -i listen
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at addListener (events.js:160:15)
    at Logger.add (/Users/rroemer/scm/fmd/express-winston-middleware/node_modules/winston/lib/winston/logger.js:456:12)
    at /Users/rroemer/scm/fmd/express-winston-middleware/node_modules/winston/lib/winston/logger.js:62:12
    at Array.forEach (native)
    at new exports.Logger (/Users/rroemer/scm/fmd/express-winston-middleware/node_modules/winston/lib/winston/logger.js:61:24)
    at new Log (/Users/rroemer/scm/fmd/express-winston-middleware/index.js:217:15)
    at Object.handle (/Users/rroemer/scm/fmd/express-winston-middleware/index.js:74:25)
    at next (/Users/rroemer/scm/fmd/express-winston-middleware/node_modules/express/node_modules/connect/lib/proto.js:193:15)
    at Object.expressInit [as handle] (/Users/rroemer/scm/fmd/express-winston-middleware/node_modules/express/lib/middleware.js:30:5)
    at next (/Users/rroemer/scm/fmd/express-winston-middleware/node_modules/express/node_modules/connect/lib/proto.js:193:15)
^C

```

vs. this branch/PR

```
$ git checkout chore-request-logger-internal-singleton
$ node examples/server.js | grep -i listen
```